### PR TITLE
State support

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -72,15 +72,35 @@ Strategy.prototype.authenticate = function (req, options) {
         return this.fail();
     }
 
+    var callbackURL = options.callbackURL || config.callbackURL;
+    if (callbackURL) {
+        var parsed = url.parse(callbackURL);
+        if (!parsed.protocol) {
+            // The callback URL is relative, resolve a fully qualified URL from the
+            // URL of the originating request.
+            callbackURL = url.resolve(utils.originalURL(req), callbackURL);
+        }
+    }
+
     if (req.query && req.query.code) {
         // If there's a state in the qs, we need to verify it matches our cookie
         if (req.query.state && options.response) {
             var state = req.query.state,
-                origState = req.cookies.state;
-            console.log('Checking state: Cookie: ' + origState + ' | QS: ' + state);
-            options.response.clearCookie('state');
-            if (!origState || state !== origState) {
-                self.error(new Error('invalid state', err));
+                cookieState = req.cookies['openid-connect-state'];
+            // Extract the state cookie and remove it from the user's cookies
+            options.response.clearCookie('openid-connect-state');
+            if (!cookieState || state !== cookieState) {
+                console.error('openid-connect auth failed, state is invalid. Expected ' + state + ' but cookie was ' + cookieState);
+
+                // State is invalid, so redirect back to the callbackURL, but make sure we remove the
+                var urlObj = url.parse(callbackURL, true);
+                delete urlObj.query.state;
+                delete urlObj.query.code;
+                delete urlObj.search;
+                callbackURL = url.format(urlObj);
+
+                console.error('redirecting to ' + callbackURL);
+                return self.redirect(callbackURL);
             }
         }
         var code = req.query.code;
@@ -112,10 +132,7 @@ Strategy.prototype.authenticate = function (req, options) {
                 }
 
                 console.log('TOKEN');
-                console.log('AT: ' + accessToken);
-                console.log('RT: ' + refreshToken);
                 console.log(params);
-                console.log('----');
 
                 var idToken = params['id_token'];
                 if (!idToken) {
@@ -157,16 +174,6 @@ Strategy.prototype.authenticate = function (req, options) {
                 return self.error(err);
             }
 
-            var callbackURL = options.callbackURL || config.callbackURL;
-            if (callbackURL) {
-                var parsed = url.parse(callbackURL);
-                if (!parsed.protocol) {
-                    // The callback URL is relative, resolve a fully qualified URL from the
-                    // URL of the originating request.
-                    callbackURL = url.resolve(utils.originalURL(req), callbackURL);
-                }
-            }
-
             var params = self.authorizationParams(req, options);
             params['response_type'] = 'code';
             params['client_id'] = config.clientID;
@@ -183,8 +190,8 @@ Strategy.prototype.authenticate = function (req, options) {
 
             // If there is a state param, we need to store it in a cookie so we can verify it later
             if (params['state'] && options.response) {
-                console.log('Writing state to cookie: ' + params['state']);
-                options.response.cookie('state', params['state'], { httpOnly: true });
+                // Write cookie to the current domain
+                options.response.cookie('openid-connect-state', params['state'], { httpOnly: true });
             }
 
             var location = config.authorizationURL + '?' + querystring.stringify(params);

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -72,8 +72,17 @@ Strategy.prototype.authenticate = function (req, options) {
         return this.fail();
     }
 
-
     if (req.query && req.query.code) {
+        // If there's a state in the qs, we need to verify it matches our cookie
+        if (req.query.state && options.response) {
+            var state = req.query.state,
+                origState = req.cookies.state;
+            console.log('Checking state: Cookie: ' + origState + ' | QS: ' + state);
+            options.response.clearCookie('state');
+            if (!origState || state !== origState) {
+                self.error(new Error('invalid state', err));
+            }
+        }
         var code = req.query.code;
 
         this.configure(null, function (err, config) {
@@ -172,6 +181,12 @@ Strategy.prototype.authenticate = function (req, options) {
                 params.scope = 'openid';
             }
 
+            // If there is a state param, we need to store it in a cookie so we can verify it later
+            if (params['state'] && options.response) {
+                console.log('Writing state to cookie: ' + params['state']);
+                options.response.cookie('state', params['state'], { httpOnly: true });
+            }
+
             var location = config.authorizationURL + '?' + querystring.stringify(params);
             self.redirect(location);
         });
@@ -247,7 +262,9 @@ Strategy.prototype.configure = function (identifier, done) {
  * @api protected
  */
 Strategy.prototype.authorizationParams = function (req, options) {
-    return {};
+    return {
+        state: utils.uid(16)
+    };
 };
 
 /**

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -111,18 +111,7 @@ Strategy.prototype.authenticate = function (req, options) {
                 return self.error(err);
             }
 
-            var oauth2 = new OAuth2(config.clientID, config.clientSecret,
-                '', config.authorizationURL, config.tokenURL);
-
-            var callbackURL = options.callbackURL || config.callbackURL;
-            if (callbackURL) {
-                var parsed = url.parse(callbackURL);
-                if (!parsed.protocol) {
-                    // The callback URL is relative, resolve a fully qualified URL from the
-                    // URL of the originating request.
-                    callbackURL = url.resolve(utils.originalURL(req), callbackURL);
-                }
-            }
+            var oauth2 = new OAuth2(config.clientID, config.clientSecret, '', config.authorizationURL, config.tokenURL);
 
             oauth2.getOAuthAccessToken(code, {
                 grant_type: 'authorization_code',

--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -27,6 +27,7 @@ function Strategy(options) {
     passport.Strategy.call(this);
     this.name = 'openidconnect';
     this._verify = options.verify;
+    this._generateNonce = options.generateNonce;
 
     this._identifierField = options.identifierField || 'openid_identifier';
     this._scope = options.scope;
@@ -269,9 +270,13 @@ Strategy.prototype.configure = function (identifier, done) {
  * @api protected
  */
 Strategy.prototype.authorizationParams = function (req, options) {
-    return {
+    var params = {
         state: utils.uid(16)
     };
+    if (this._generateNonce) {
+        params.nonce = utils.uid(16)
+    }
+    return params;
 };
 
 /**


### PR DESCRIPTION
Add support to properly ensure that `state` is verified when using openid-connect according to the spec.

**note:** this requires the consumer to pass the `res` object in via a `response` optional param when calling `passport.authenticate`.
