### PR TITLE
Explicitly require and include cookie-parser middleware

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -86,13 +86,24 @@ Strategy.prototype.authenticate = function (req, options) {
     if (req.query && req.query.code) {
         // If there's a state in the qs, we need to verify it matches our cookie
         if (req.query.state && options.response) {
-            var state = req.query.state,
-                cookieState = req.cookies['openid-connect-state'];
-            // Extract the state cookie and remove it from the user's cookies
-            options.response.clearCookie('openid-connect-state');
-            if (!cookieState || state !== cookieState) {
-                console.error('openid-connect auth failed, state is invalid. Expected ' + state + ' but cookie was ' + cookieState);
+            var failed = false;
+            // Ensure we have cookie-parser middleware for cookie manipulation
+            require('cookie-parser')()(req, options.response, function (err) {
+                if (err) {
+                    console.error('error parsing cookies with cookie-parser middleware', err);
+                    return failed = true;
+                }
 
+                var state = req.query.state,
+                    cookieState = req.cookies['openid-connect-state'];
+                // Extract the state cookie and remove it from the user's cookies
+                options.response.clearCookie('openid-connect-state');
+                if (!cookieState || state !== cookieState) {
+                    console.error('openid-connect auth failed, state is invalid. Expected ' + state + ' but cookie was ' + cookieState);
+                    return failed = true;
+                }
+            });
+            if (failed) {
                 return self.fail();
             }
         }
@@ -173,7 +184,12 @@ Strategy.prototype.authenticate = function (req, options) {
             // If there is a state param, we need to store it in a cookie so we can verify it later
             if (params['state'] && options.response) {
                 // Write cookie to the current domain
-                options.response.cookie('openid-connect-state', params['state'], { httpOnly: true });
+                // Ensure we have cookie-parser middleware for cookie manipulation
+                require('cookie-parser')()(req, options.response, function (err) {
+                    if (!err) {
+                        options.response.cookie('openid-connect-state', params['state'], { httpOnly: true });
+                    }
+                });
             }
 
             var location = config.authorizationURL + '?' + querystring.stringify(params);

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   ],
   "main": "./lib",
   "dependencies": {
+    "cookie-parser": "~1.4.3",
     "jsonwebtoken": "^6.2.0",
     "oauth": "0.9.x",
     "passport": "~0.1.1",


### PR DESCRIPTION
We need the cookie-parser middleware to write/read cookies, and we don't want to make the consumer have to include the dependency.  So, we'll manually include it and use it ourselves.

cookie-parser handles the case where something else has already included and initialized it, so we're safe to do it multiple times.
